### PR TITLE
pry-bond is now running on the pry head version without errors

### DIFF
--- a/lib/pry-bond.rb
+++ b/lib/pry-bond.rb
@@ -1,2 +1,3 @@
 require "pry" unless defined?(Pry)
+require "bond"
 require "pry/bond"

--- a/lib/pry/bond.rb
+++ b/lib/pry/bond.rb
@@ -2,5 +2,8 @@ require_relative "bond/version"
 require_relative "bond/completer"
 require_relative "bond/enable_command"
 require_relative "bond/disable_command"
-module Pry::Bond
+# Pry::Bond is not the best name for a namespace,
+# because all references to Bond from Pry now
+# pointing to the "wrong" module
+module Pry::BondCompleter
 end

--- a/lib/pry/bond/completer.rb
+++ b/lib/pry/bond/completer.rb
@@ -10,12 +10,12 @@ module Pry::BondCompleter
   # pass local '_pry_' in favor of Pry.current().
   def self.start
     Bond.start(:eval_binding => lambda{ Pry.current[:pry] && Pry.current[:pry].current_context })
-    Bond.complete(:on => /\A/) do |input|
-      Pry.commands.complete(input.line,
+    Bond.complete(:on => /^(.+)$/, :place => :last, :name => "pry-autocomplete", :action => lambda {|input|
+      Bond::DefaultMission.completions.map(&:to_s) + Pry.commands.complete(input.line,
                             :pry_instance => Pry.current[:pry],
                             :target       => Pry.current[:pry].current_context,
                             :command_set  => Pry.current[:pry].commands)
-    end
+    })
     self
   end
 end

--- a/lib/pry/bond/default.rb
+++ b/lib/pry/bond/default.rb
@@ -1,2 +1,2 @@
 require "pry-bond"
-Pry.config.completer = Proc.new { Pry::BondCompleter.start }
+Pry.config.completer = Pry::BondCompleter.start

--- a/lib/pry/bond/disable_command.rb
+++ b/lib/pry/bond/disable_command.rb
@@ -1,4 +1,4 @@
-class Pry::Bond::DisableCommand < Pry::ClassCommand
+class Pry::BondCompleter::DisableCommand < Pry::ClassCommand
   match 'disable-bond!'
   group 'bond'
   description 'disable input completion through the `bond` rubygem.'

--- a/lib/pry/bond/enable_command.rb
+++ b/lib/pry/bond/enable_command.rb
@@ -1,4 +1,4 @@
-class Pry::Bond::EnableCommand < Pry::ClassCommand
+class Pry::BondCompleter::EnableCommand < Pry::ClassCommand
   match 'enable-bond!'
   group 'bond'
   description 'enable input completion through the `bond` rubygem.'

--- a/lib/pry/bond/version.rb
+++ b/lib/pry/bond/version.rb
@@ -1,5 +1,5 @@
 class Pry
-  module Bond
+  module BondCompleter
     VERSION = "0.0.1"
   end
 end

--- a/pry-bond.gemspec
+++ b/pry-bond.gemspec
@@ -1,7 +1,7 @@
 require "./lib/pry/bond/version"
 Gem::Specification.new do |spec|
   spec.name          = "pry-bond"
-  spec.version       = Pry::Bond::VERSION
+  spec.version       = Pry::BondCompleter::VERSION
   spec.authors       = ["Public Domain"]
   spec.email         = ["robert@flowof.info"]
   spec.description   = "pry-bond provides input completion in pry through the `bond` rubygem."


### PR DESCRIPTION
- rename Pry::Bond to Pry::BondCompleter to avoid name clashing
- Bond's completions have now higher precedence than Pry's completions
- moving the closure into the action option
- add Bond's standard completions to Pry's command set completions, as
  it was the case for earlier versions of Pry
