### PR TITLE
pry-bond is now compatible to pry/pry@193a229

### DIFF
--- a/lib/pry/bond.rb
+++ b/lib/pry/bond.rb
@@ -5,5 +5,5 @@ require_relative "bond/disable_command"
 # Pry::Bond is not the best name for a namespace,
 # because all references to Bond from Pry now
 # pointing to the "wrong" module
-module Pry::BondCompleter
+class Pry::BondCompleter
 end

--- a/lib/pry/bond/completer.rb
+++ b/lib/pry/bond/completer.rb
@@ -30,7 +30,7 @@ class Pry
       })
     end
 
-    def self.with_pry_instance instance
+    def self.with_pry instance
       @lock.synchronize do
         begin
           @current_pry_instance = instance
@@ -41,22 +41,22 @@ class Pry
       end
     end
 
-    def initialize pry_instance
+    def initialize input, pry = nil
       BondCompleter.setup if BondCompleter.bond.nil?
-      @pry_instance = pry_instance
+      @pry = pry
+      @input = input
     end
 
-    def call(input, options)
-      BondCompleter.with_pry_instance(@pry_instance) {BondCompleter.bond.agent.call(input, get_full_line_input || input)}
+    def call str, options
+      BondCompleter.with_pry(@pry) {BondCompleter.bond.agent.call(str, get_full_line_input || str)}
     end
 
     protected
     def get_full_line_input
-      input = @pry_instance.input
-      if input.respond_to?(:line_buffer)
-        input.line_buffer
-      elsif input.respond_to? :line
-        input.line
+      if @input.respond_to?(:line_buffer)
+        @input.line_buffer
+      elsif @input.respond_to? :line
+        @input.line
       else
         nil
       end

--- a/lib/pry/bond/completer.rb
+++ b/lib/pry/bond/completer.rb
@@ -1,21 +1,66 @@
-module Pry::BondCompleter
-  # TODO:
-  # remove `Pry.current[:pry]`.
-  def self.call(input, options)
-    Pry.current[:pry] = options[:pry]
-    Bond.agent.call(input)
-  end
+class Pry
+  class BondCompleter
 
-  # TODO:
-  # pass local '_pry_' in favor of Pry.current().
-  def self.start
-    Bond.start(:eval_binding => lambda{ Pry.current[:pry] && Pry.current[:pry].current_context })
-    Bond.complete(:on => /^(.+)$/, :place => :last, :name => "pry-autocomplete", :action => lambda {|input|
-      Bond::DefaultMission.completions.map(&:to_s) + Pry.commands.complete(input.line,
-                            :pry_instance => Pry.current[:pry],
-                            :target       => Pry.current[:pry].current_context,
-                            :command_set  => Pry.current[:pry].commands)
-    })
-    self
+    class << self
+      attr_reader :bond
+    end
+
+    class NoopReadline
+      def self.setup _
+        # do nothing as we let pry do the completion
+      end
+
+      def self.line_buffer
+        "" # we give the current line directly to bond
+      end
+    end
+
+    def self.setup(config={})
+      @lock = Mutex.new
+      @bond = Bond::M
+      @bond.config.merge!(config)
+      @bond.config[:readline] ||= NoopReadline
+      @current_pry_instance = nil
+      @bond.start(:eval_binding => lambda {@current_pry_instance.current_binding})
+      @bond.complete(:on => /^(.+)$/, :place => :last, :name => "pry-autocomplete", :action => lambda {|input|
+        Bond::DefaultMission.completions.map(&:to_s) + Pry.commands.complete(input.line,
+                              :pry_instance => @current_pry_instance,
+                              :target       => @current_pry_instance.current_binding,
+                              :command_set  => @current_pry_instance.commands)
+      })
+    end
+
+    def self.with_pry_instance instance
+      @lock.synchronize do
+        begin
+          @current_pry_instance = instance
+          yield
+        ensure
+          @current_pry_instance = nil 
+        end
+      end
+    end
+
+    def initialize pry_instance
+      BondCompleter.setup if BondCompleter.bond.nil?
+      @pry_instance = pry_instance
+    end
+
+    def call(input, options)
+      BondCompleter.with_pry_instance(@pry_instance) {BondCompleter.bond.agent.call(input, get_full_line_input || input)}
+    end
+
+    protected
+    def get_full_line_input
+      input = @pry_instance.input
+      if input.respond_to?(:line_buffer)
+        input.line_buffer
+      elsif input.respond_to? :line
+        input.line
+      else
+        nil
+      end
+    end
+
   end
 end

--- a/lib/pry/bond/default.rb
+++ b/lib/pry/bond/default.rb
@@ -1,2 +1,2 @@
 require "pry-bond"
-Pry.config.completer = Pry::BondCompleter.start
+Pry.config.completer = Pry::BondCompleter

--- a/lib/pry/bond/enable_command.rb
+++ b/lib/pry/bond/enable_command.rb
@@ -8,7 +8,7 @@ class Pry::BondCompleter::EnableCommand < Pry::ClassCommand
   BANNER
 
   def process
-    _pry_.config.completer = Pry::BondCompleter.start
+    _pry_.config.completer = Pry::BondCompleter
     output.puts heading("bond input completion has been enabled and is ready to use!")
   end
   Pry.commands.add_command(self)


### PR DESCRIPTION
- Pry::BondCompleter is now a class that is initialized with a Pry instance (to deal with pry/pry@193a229)
- Bond does not use Readline directly, anymore. Instead, Bond gets its input from Pry#complete
- But Bond uses still a global state. The local Pry instance is set before each completion call (using a Mutex to deal with parallel completion requests)
